### PR TITLE
Removes Netflix from the OSSLifecycle badge txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fibtest
 
-![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/indeedeng/fibtest.svg)
+![OSS Lifecycle](https://img.shields.io/osslifecycle/indeedeng/fibtest.svg)
 
 Fibtest is a small C application that runs the fibonacci sequence and reports
 how many iterations it completed.


### PR DESCRIPTION
Fixes an erroneous cut-and-paste error from shields.io, which referenced Netflix in the OSSLifecycle badge alternate text.